### PR TITLE
add dockerfile for creating conda env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM continuumio/miniconda3
+
+# setting Conda Path
+ENV PATH /opt/conda/bin:$PATH
+
+COPY environment.yml .
+RUN conda env create -f environment.yml
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.9'
+services:
+  app:
+    build: .
+    # dockerfile: Dockerfile
+    container_name: 'beyond-jupyter'
+    working_dir: '/workspace'
+    volumes:
+      - ./:/workspace/
+    ports:
+      - 8888:8888
+
+    tty: true
+    networks:
+      - db_network
+
+networks:
+  db_network:
+    external: true


### PR DESCRIPTION
dockerfile
```
FROM continuumio/miniconda3

# setting Conda Path
ENV PATH /opt/conda/bin:$PATH

COPY environment.yml .
RUN conda env create -f environment.yml
```

docker-compse.yml
```
version: '3.9'
services:
  app:
    build: .
    # dockerfile: Dockerfile
    container_name: 'beyond-jupyter'
    working_dir: '/workspace'
    volumes:
      - ./:/workspace/
    ports:
      - 8888:8888

    tty: true
    networks:
      - db_network

networks:
  db_network:
    external: true
```

Use conda with docker

    beyond-jupyter % docker-compose up -d app
    beyond-jupyter % docker-compose exec app /bash/bin
    # on docker container
    /workspace# source activate pop
access jyupyterlab

    # on docker container
    /workspace# jupyter lab --allow-root --no-browser --NotebookApp.token='' --port 8888 --ip=0.0.0.0
Access with a browser to http://localhost:8888/