### PR TITLE
docs: Update VSCode shortcuts in README for navigation and file switc…

### DIFF
--- a/oop-essentials/05-ide-features/README.md
+++ b/oop-essentials/05-ide-features/README.md
@@ -168,7 +168,7 @@ When jumping between positions in the code (e.g. in conjunction with "go to defi
 | IDE       | Shortcut                                 |
 | --------- |------------------------------------------|
 | JetBrains | Ctrl+Alt+Left/Right (Cmd+Opt+Left/Right) |
-| VSCode    | Alt+Left/Right (Opt+Left/Right)          |
+| VSCode    | Alt+Left/Right (Ctrl+-/Ctrl+Shift+-)     |
 
 ### Recently/Previously Used Files/Editors
 
@@ -177,7 +177,7 @@ When jumping between files, being able to quickly return to a previous file (wit
 | IDE       | Shortcut                    |
 | --------- |-----------------------------|
 | JetBrains | Ctrl+E (Cmd+E)              |
-| VSCode    | Ctrl+Tab (Cmd+Tab)          |
+| VSCode    | Ctrl+Tab (Ctrl+Tab)         |
 
 ## Editing
 


### PR DESCRIPTION
This pull request updates the keyboard shortcut documentation for VSCode in the `oop-essentials/05-ide-features/README.md` file to clarify the correct key combinations for navigating code and files for **MacOS**.

**Documentation improvements:**

* Updated the VSCode default shortcut for back/forward navigation from `Opt+Left/Right` to `Ctrl+-/Ctrl+Shift+-`.
* Updated the VSCode shortcut for switching to recently used files, from `Cmd+Tab` to `Ctrl+Tab`.